### PR TITLE
Update ffi_lib definitions to work on OS X and other non-standard install locations

### DIFF
--- a/lib/svn/apr_utils.rb
+++ b/lib/svn/apr_utils.rb
@@ -39,7 +39,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libapr-1.so.0'
+      ffi_lib ['libapr-1', 'libapr-1.so.0']
 
       typedef :pointer, :index
       typedef :pointer, :out_pointer
@@ -219,7 +219,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libapr-1.so.0'
+      ffi_lib ['libapr-1', 'libapr-1.so.0']
 
       typedef :pointer, :index
       typedef :pointer, :out_pointer

--- a/lib/svn/diffs.rb
+++ b/lib/svn/diffs.rb
@@ -158,7 +158,7 @@ module Svn #:nodoc:
     module C
 
       extend FFI::Library
-      ffi_lib 'libsvn_diff-1.so.1'
+      ffi_lib ['libsvn_diff-1', 'libsvn_diff-1.so.1']
 
       typedef :pointer, :out_pointer
       typedef Pool, :pool

--- a/lib/svn/errors.rb
+++ b/lib/svn/errors.rb
@@ -99,7 +99,7 @@ module Svn
 
     module C
       extend FFI::Library
-      ffi_lib 'libsvn_subr-1.so.1'
+      ffi_lib ['libsvn_subr-1', 'libsvn_subr-1.so.1']
 
       typedef CError.by_ref, :error
       typedef :int, :size

--- a/lib/svn/pools.rb
+++ b/lib/svn/pools.rb
@@ -22,7 +22,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libapr-1.so.0'
+      ffi_lib ['libapr-1', 'libapr-1.so.0']
 
       typedef :int, :apr_status
       typedef Pool, :pool

--- a/lib/svn/repos.rb
+++ b/lib/svn/repos.rb
@@ -99,7 +99,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libsvn_repos-1.so.1'
+      ffi_lib ['libsvn_repos-1', 'libsvn_repos-1.so.1']
 
       # convenience pointers
       typedef :pointer, :out_pointer
@@ -214,7 +214,7 @@ module Svn #:nodoc:
       #    [ :out_pointer, :repo, :out_pointer, :transaction ],
       #    :error
 
-      ffi_lib 'libsvn_fs-1.so.1'
+      ffi_lib ['libsvn_fs-1', 'libsvn_fs-1.so.1']
 
       # youngest revision number accessor
       attach_function :youngest,

--- a/lib/svn/revisions.rb
+++ b/lib/svn/revisions.rb
@@ -32,7 +32,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libsvn_fs-1.so.1'
+      ffi_lib ['libsvn_fs-1', 'libsvn_fs-1.so.1']
 
       typedef :pointer, :out_pointer
       typedef Pool, :pool

--- a/lib/svn/roots.rb
+++ b/lib/svn/roots.rb
@@ -13,7 +13,7 @@ module Svn #:nodoc:
 
     module C
       extend FFI::Library
-      ffi_lib 'libsvn_fs-1.so.1'
+      ffi_lib ['libsvn_fs-1', 'libsvn_fs-1.so.1']
 
       typedef :pointer, :out_pointer
       typedef Pool, :pool

--- a/lib/svn/streams.rb
+++ b/lib/svn/streams.rb
@@ -24,7 +24,7 @@ module Svn
 
     module C
       extend FFI::Library
-      ffi_lib 'libsvn_subr-1.so.1'
+      ffi_lib ['libsvn_subr-1', 'libsvn_subr-1.so.1']
 
       typedef :pointer, :in_out_len
       typedef CError.by_ref, :error


### PR DESCRIPTION
FFI's ffi_lib provides some magic to match dynamic libraries on platforms that don't use an explicit .so or .so.0, etc naming scheme.  For example, OS X, where dynamic libraries are suffixed .dylib.  I couldn't get this gem to install and run on an OS X system without the changes in this pull request.

Cheers,

Brandon
